### PR TITLE
Added parent config functionality

### DIFF
--- a/config_der.json
+++ b/config_der.json
@@ -1,5 +1,6 @@
 {
-"50":{"basic_specs":{"n_phases":3},
+"50":{"parent_config":"",
+      "basic_specs":{"n_phases":3},
       "basic_options":{"Sinsol":100.0},
       "module_parameters":{"Np":11,"Ns":735,"Vdcmpp0":550.0,"Vdcmpp_min": 525.0,"Vdcmpp_max": 650.0},
                           
@@ -16,9 +17,10 @@
       "initial_states":{"iaR":0,"iaI":0.0,"xaR":0.0,"xaI":0.0,"uaR":0.0,"uaI":0.0,
                         "xDC":0.0,"xQ":0.0,"xPLL":0.0,"wte":6.28}
      },
-    "250":{"basic_specs":{"n_phases":3},
-          "basic_options":{"Sinsol":100.0},
-      "module_parameters":{"Np":45,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 750.0,"Vdcmpp_max": 1000.0},
+    "250":{"parent_config":"",
+           "basic_specs":{"n_phases":3},
+           "basic_options":{"Sinsol":100.0},
+           "module_parameters":{"Np":45,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 750.0,"Vdcmpp_max": 1000.0},
                           
       "inverter_ratings":{"Srated":250e3,"Vdcrated":750.0,"Ioverload":1.3,"Vrmsrated":230.0},
       
@@ -34,7 +36,8 @@
                         "xDC":0.0,"xQ":0.0,"xPLL":0.0,"wte":6.28}
      },
 
-"10":{"basic_specs":{"n_phases":1},
+"10":{"parent_config":"",
+      "basic_specs":{"n_phases":1},
       "basic_options":{"Sinsol":100.0},
       "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
       
@@ -52,7 +55,8 @@
                         "xDC":0.0,"xQ":0.0,"xPLL":0.0,"wte":6.28}
       
      },
-"10_constantVdc":{"basic_specs":{"n_phases":1},
+"10_constantVdc":{"parent_config":"",
+                  "basic_specs":{"n_phases":1},
                   "basic_options":{"Sinsol":100.0},
       "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
       
@@ -71,8 +75,9 @@
       
      },
     
-"1":{"basic_specs":{"n_phases":1,"Sinsol":100.0},
-	 "basic_options":{"Sinsol":100.0},
+"1":{"parent_config":"",
+     "basic_specs":{"n_phases":1,"Sinsol":100.0},
+     "basic_options":{"Sinsol":100.0},
      "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
      "inverter_ratings":{"Srated":10e3,"Varated":250.0,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},
      

--- a/pvder/dynamic_simulation.py
+++ b/pvder/dynamic_simulation.py
@@ -22,7 +22,7 @@ class DynamicSimulation(Grid,SimulationUtilities,Logging):
     count = 0
     tStart = 0.0
     tInc = defaults.DEFAULT_DELTA_T
-    #jacFlag = False
+    
     DEBUG_SOLVER = False
     DEBUG_SIMULATION = False
     DEBUG_CONTROLLERS = False
@@ -30,6 +30,8 @@ class DynamicSimulation(Grid,SimulationUtilities,Logging):
     DEBUG_CURRENTS = False
     DEBUG_POWER = False
     DEBUG_PLL = False
+    
+    jac_list = ['SolarPV_DER_ThreePhase','SolarPV_DER_SinglePhase']
         
     def __init__(self,PV_model,events,grid_model = None,tStop = 0.5,
                  LOOP_MODE = False,COLLECT_SOLUTION = True,jacFlag = False,
@@ -44,11 +46,8 @@ class DynamicSimulation(Grid,SimulationUtilities,Logging):
           tInc: A scalar specifying the time step for simulation.
           LOOP_MODE: A boolean specifying whether simulation is run in loop.
         """
-        #if LOOP_MODE:
-        #    assert not PV_model.standAlone, 'Loop mode can only be true if PV-DER model is stand alone.'
-        
-        #Increment count to keep track of number of simulation instances
-        DynamicSimulation.count = DynamicSimulation.count + 1
+                       
+        DynamicSimulation.count = DynamicSimulation.count + 1 #Increment count to keep track of number of simulation instances
         self.name_instance(identifier) #Generate a name for the instance
         
         self.initialize_logger(logging_level=verbosity) #Set logging level - {DEBUG,INFO,WARNING,ERROR}  

--- a/pvder/templates.py
+++ b/pvder/templates.py
@@ -58,7 +58,8 @@ controller_properties = {"current_controller":{"gains":["Kp_GCC","Ki_GCC","wp"],
                          }
 
 DER_design_template = {"SolarPV_DER_SinglePhase":
-                       {"basic_specs":{'phases':('a'),'n_phases':1,'n_ODE':11},
+                       {"parent_config":"",
+                        "basic_specs":{'phases':('a'),'n_phases':1,'n_ODE':11},
                         "basic_options":{'t_stable':0.5,'m_steady_state':0.96,"Sinsol":100.0},
                        "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
                        "inverter_ratings":{"Srated":10e3,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},
@@ -72,7 +73,8 @@ DER_design_template = {"SolarPV_DER_SinglePhase":
                        },
                        
                        "SolarPV_DER_ThreePhase":
-                       {"basic_specs":{'phases':('a','b','c'),'n_phases':3,'n_ODE':23,'unbalanced':True},
+                       {"parent_config":"",
+                        "basic_specs":{'phases':('a','b','c'),'n_phases':3,'n_ODE':23,'unbalanced':True},
                         "basic_options":{'t_stable':0.5,'m_steady_state':0.96,"Sinsol":100.0},
                         "module_parameters":{"Np":11,"Ns":735,"Vdcmpp0":550.0,"Vdcmpp_min": 525.0,"Vdcmpp_max": 650.0}, 
                         "inverter_ratings":{"Srated":50e3,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},
@@ -86,7 +88,8 @@ DER_design_template = {"SolarPV_DER_SinglePhase":
                        },
                        
                        "SolarPVDERThreePhaseBalanced":
-                       {"basic_specs":{'phases':('a','b','c'),'n_phases':3,'n_ODE':11,'unbalanced':False},
+                       {"parent_config":"",
+                        "basic_specs":{'phases':('a','b','c'),'n_phases':3,'n_ODE':11,'unbalanced':False},
                         "basic_options":{'t_stable':0.5,'m_steady_state':0.96,"Sinsol":100.0},
                        "module_parameters":{"Np":11,"Ns":735,"Vdcmpp0":550.0,"Vdcmpp_min": 525.0,"Vdcmpp_max": 650.0}, 
                        "inverter_ratings":{"Srated":50e3,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},
@@ -100,7 +103,8 @@ DER_design_template = {"SolarPV_DER_SinglePhase":
                         },
                        
                        "SolarPVDER_SinglePhaseConstantVdc":
-                       {"basic_specs":{'phases':('a'),'n_phases':1,'n_ODE':10},
+                       {"parent_config":"",
+                        "basic_specs":{'phases':('a'),'n_phases':1,'n_ODE':10},
                         "basic_options":{'t_stable':0.5,'m_steady_state':0.96,"Sinsol":100.0,'use_Pref':False},
                        "module_parameters":{"Np":2,"Ns":1000,"Vdcmpp0":750.0,"Vdcmpp_min": 650.0,"Vdcmpp_max": 800.0},
                        "inverter_ratings":{"Srated":10e3,"Vdcrated":550.0,"Ioverload":1.3,"Vrmsrated":177.0},


### PR DESCRIPTION
Adding functionality to allow users to create new DER configs by overriding one or more parameters from the existing DER config. For e.g.  the configuration `"50_type1":{"parent_config":"50","inverter_ratings":{"Ioverload":1.0}` will use "50" as a parent and will derive all parameters from it except for "Ioverload".