### PR TITLE
Change RT voltage measurement

### DIFF
--- a/pvder/DER_components_single_phase.py
+++ b/pvder/DER_components_single_phase.py
@@ -150,7 +150,8 @@ class SolarPVDERSinglePhase(PVModule,SolarPVDER):
         """Update RMS voltages."""
         
         self.Vtrms = self.Vtrms_calc()
-        self.Vrms = self.Vrms_calc()
+        self.Vrms_min = self.Vrms = self.Vrms_calc()
+        
         self.Irms = self.Irms_calc()
         
         #Update RMS values

--- a/pvder/DER_components_single_phase_constant_Vdc.py
+++ b/pvder/DER_components_single_phase_constant_Vdc.py
@@ -145,7 +145,8 @@ class SolarPVDERSinglePhaseConstantVdc(PVModule,SolarPVDER):
         """Update RMS voltages."""
         
         self.Vtrms = self.Vtrms_calc()
-        self.Vrms = self.Vrms_calc()
+        self.Vrms_min = self.Vrms = self.Vrms_calc()
+        
         self.Irms = self.Irms_calc()
         
         #Update RMS values

--- a/pvder/DER_components_three_phase.py
+++ b/pvder/DER_components_three_phase.py
@@ -109,6 +109,11 @@ class SolarPVDERThreePhase(PVModule,SolarPVDER):
         
         return utility_functions.Urms_calc(self.va,self.vb,self.vc)
     
+    def Vrms_min_calc(self):
+        """PCC LV side voltage - RMS"""
+        
+        return utility_functions.Urms_min_calc(self.va,self.vb,self.vc)
+        
     def Irms_calc(self):
         """Inverter current - RMS"""
         
@@ -167,6 +172,8 @@ class SolarPVDERThreePhase(PVModule,SolarPVDER):
         
         self.Vtrms = self.Vtrms_calc()
         self.Vrms = self.Vrms_calc()
+        self.Vrms_min = self.Vrms_min_calc()
+        
         self.Irms = self.Irms_calc()
         
         #Update RMS values

--- a/pvder/DER_components_three_phase_balanced.py
+++ b/pvder/DER_components_three_phase_balanced.py
@@ -159,7 +159,8 @@ class SolarPVDERThreePhaseBalanced(PVModule,SolarPVDER):
         """Update RMS voltages."""
         
         self.Vtrms = self.Vtrms_calc()
-        self.Vrms = self.Vrms_calc()
+        self.Vrms_min = self.Vrms = self.Vrms_calc()
+        
         self.Irms = self.Irms_calc()
         
         #Update RMS values

--- a/pvder/DER_components_three_phase_constant_Vdc.py
+++ b/pvder/DER_components_three_phase_constant_Vdc.py
@@ -109,6 +109,11 @@ class SolarPVDERThreePhaseConstantVdc(PVModule,SolarPVDER):
         
         return utility_functions.Urms_calc(self.va,self.vb,self.vc)
     
+    def Vrms_min_calc(self):
+        """PCC LV side voltage - RMS"""
+        
+        return utility_functions.Urms_min_calc(self.va,self.vb,self.vc)
+          
     def Irms_calc(self):
         """Inverter current - RMS"""
         
@@ -168,6 +173,8 @@ class SolarPVDERThreePhaseConstantVdc(PVModule,SolarPVDER):
         
         self.Vtrms = self.Vtrms_calc()
         self.Vrms = self.Vrms_calc()
+        self.Vrms_min = self.Vrms_min_calc()
+        
         self.Irms = self.Irms_calc()
         
         #Update RMS values

--- a/pvder/DER_features.py
+++ b/pvder/DER_features.py
@@ -219,8 +219,8 @@ class PVDER_SmartFeatures():
     def DER_reconnect_logic(self,t):
         """Logic used to decide reconnection."""
         
-        #Select RMS voltage source
-        Vrms_measured = self.Vrms   #Select PCC - LV side voltage   
+        Vrms_measured = self.get_Vrms_measured()
+        
         fgrid = self.we/(2.0*math.pi)  #Use grid frequency as estimated by PLL
         
         assert not self.DER_CONNECTED, 'Reconnection logic can only be used if DER is disconnected.'
@@ -273,11 +273,7 @@ class PVDER_SmartFeatures():
         self.HVRT_ENABLE = True
         self.HVRT_TRIP = False
         self.HVRT_MOMENTARY_CESSATION = False
-               
-        
-        
-                
-        
+         
         self.LVRT_dict = self.RT_config['LVRT']
         self.HVRT_dict = self.RT_config['HVRT']
         
@@ -286,12 +282,11 @@ class PVDER_SmartFeatures():
         self.RESTORE_Vdc = self.RT_config['VRT_delays']['restore_Vdc'] #Restore Vdc to nominal reference by using a ramp
                           
         self.check_VRT_settings()
-    
+   
     def LVRT(self,t):
         """Function to implement LVRT ridethrough and trip logic."""
         
-        #Select RMS voltage source
-        Vrms_measured = self.Vrms   #Select PCC - LV side voltage             
+        Vrms_measured = self.get_Vrms_measured()
         
         if t > self.t_stable: #Go through logic only after a short time delay
             for LVRT_key,LVRT_values in self.LVRT_dict.items():
@@ -330,8 +325,7 @@ class PVDER_SmartFeatures():
     def HVRT(self,t):
         """Function to implement HVRT ridethrough and trip logic."""
         
-        #Select RMS voltage source
-        Vrms_measured = self.Vrms   #Select PCC - LV side voltage     
+        Vrms_measured = self.get_Vrms_measured()
         
         if t > self.t_stable: #Go through logic only after a short time delay
             for HVRT_key,HVRT_values in self.HVRT_dict.items():
@@ -365,6 +359,17 @@ class PVDER_SmartFeatures():
                     else: #Do nothing
                         pass
     
+    def get_Vrms_measured(self):
+        """Get Vrms measurement"""
+         
+        #Select RMS voltage source
+        if specifications.RT_measurement_type == 'minimum':
+            Vrms_measured  = self.Vrms_min  #Select minimum value of PCC-Voltages as per IEEE 1547-2018 reccomendations
+        elif specifications.RT_measurement_type == 'average':
+            Vrms_measured = self.Vrms   #Select PCC - LV side voltage  
+        
+        return Vrms_measured
+        
     def show_RT_flags(self):
         """Show all RT flags."""
         

--- a/pvder/specifications.py
+++ b/pvder/specifications.py
@@ -11,6 +11,8 @@ from pvder.grid_components import Grid
 steadystate_solver_spec = {'SLSQP':{'ftol': 1e-10, 'disp': True, 'maxiter':10000},
                'nelder-mead':{'xtol': 1e-8, 'disp': True, 'maxiter':10000}}
 
+RT_measurement_type = 'average'#average,minimum
+
 if six.PY3:
     string_type = (str)
 elif six.PY2:

--- a/pvder/utility_functions.py
+++ b/pvder/utility_functions.py
@@ -67,6 +67,13 @@ def Urms_calc(ua,ub,uc):
     
     return math.sqrt((pow(abs(ua),2)+pow(abs(ub),2)+pow(abs(uc),2))/3.0)/math.sqrt(2)  #Pure python implementation is faster      
 
+def Urms_min_calc(ua,ub,uc):
+    """Function to calculate minimum of rms value of scalar phasor quantities."""
+    
+    return min(abs(ua),abs(ub),abs(uc))/math.sqrt(2)  #Pure python implementation is faster      
+
+    return math.sqrt((pow(abs(ua),2)+pow(abs(ub),2)+pow(abs(uc),2))/3.0)/math.sqrt(2)  #Pure python implementation is faster      
+
 def Urms_calc_1phase(ua):
     """Function to calculate rms value of scalar phasor quantities for single phase."""
     

--- a/pvder/utility_functions.py
+++ b/pvder/utility_functions.py
@@ -70,10 +70,8 @@ def Urms_calc(ua,ub,uc):
 def Urms_min_calc(ua,ub,uc):
     """Function to calculate minimum of rms value of scalar phasor quantities."""
     
-    return min(abs(ua),abs(ub),abs(uc))/math.sqrt(2)  #Pure python implementation is faster      
-
-    return math.sqrt((pow(abs(ua),2)+pow(abs(ub),2)+pow(abs(uc),2))/3.0)/math.sqrt(2)  #Pure python implementation is faster      
-
+    return min(abs(ua),abs(ub),abs(uc))/math.sqrt(2)  #Pure python implementation is faster 
+   
 def Urms_calc_1phase(ua):
     """Function to calculate rms value of scalar phasor quantities for single phase."""
     


### PR DESCRIPTION
Changes the voltage measurement used by the voltage ride through logic. Earlier the average RMS value was being used but now it is possible to change it use either '_minimum_' or '_average_' using the keyword `RT_measurement_type` in specificiations.py. Default is '_minimum_'.